### PR TITLE
Remove one empty line below cap

### DIFF
--- a/lib/drop_cap_text.dart
+++ b/lib/drop_cap_text.dart
@@ -97,6 +97,9 @@ class DropCapText extends StatelessWidget {
     capHeight += dropCapPadding.top + dropCapPadding.bottom;
 
     int rows = ((capHeight - indentation.dy) / lineHeight).ceil();
+    if (rows != 0) {
+      rows--;
+    }
 
     // DROP CAP MODE - UPWARDS
     if (mode == DropCapMode.upwards) {


### PR DESCRIPTION
This fixes issue https://github.com/mtiziano/drop_cap_text/issues/2 
It subtract 1 from calculated rows count if rows > 0. On that way we don't have one extra line below cap, and it easy to add spacing with dropCapPadding if extra spacing is needed.