### PR TITLE
Fix duplicate lines / Fix blank lines on Android

### DIFF
--- a/lib/drop_cap_text.dart
+++ b/lib/drop_cap_text.dart
@@ -158,7 +158,8 @@ class DropCapText extends StatelessWidget {
       //int startMillis = new DateTime.now().millisecondsSinceEpoch;
       if (rows > 0) {
         textPainter.layout(maxWidth: boundsWidth);
-        double yPos = rows * lineHeight;
+        // Add half line height to ensure getPositionForOffset picks the right index.
+        double yPos = (rows * lineHeight) + lineHeight / 2;
         int charIndex = textPainter.getPositionForOffset(Offset(0, yPos)).offset;
         textPainter.maxLines = rows;
         textPainter.layout(maxWidth: boundsWidth);

--- a/lib/drop_cap_text.dart
+++ b/lib/drop_cap_text.dart
@@ -201,6 +201,7 @@ class DropCapText extends StatelessWidget {
                 child: Container(
                   padding: EdgeInsets.only(top: indentation.dy),
                   height: (lineHeight * min(maxLines ?? rows, rows)) + indentation.dy,
+                  width: boundsWidth,
                   child: RichText(
                     overflow: (maxLines == null || (maxLines > rows && overflow == TextOverflow.fade))
                         ? TextOverflow.clip


### PR DESCRIPTION
Proposal to fix issue #6 . Tested on iOS and Android.
Also, explicitly setting the boundsWidth on the Container fixes an issue with lines appearing blank beside the drop cap on Android.

